### PR TITLE
Change Backend to Frontend all over

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>SnackrBackend</title>
+    <title>SnackrFrontend</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,7 +19,7 @@ require "sprockets/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module SnackrBackend
+module SnackrFrontend
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -7,4 +7,4 @@ test:
 production:
   adapter: redis
   url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: snackr_backend_production
+  channel_prefix: snackr_frontend_production

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,13 +23,13 @@ default: &default
 
 development:
   <<: *default
-  database: snackr_backend_development
+  database: snackr_frontend_development
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
   # the same name as the operating system user running Rails.
-  #username: snackr_backend
+  #username: snackr_frontend
 
   # The password associated with the postgres role (username).
   #password:
@@ -57,7 +57,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: snackr_backend_test
+  database: snackr_frontend_test
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -81,6 +81,6 @@ test:
 #
 production:
   <<: *default
-  database: snackr_backend_production
-  username: snackr_backend
-  password: <%= ENV['SNACKR_BACKEND_DATABASE_PASSWORD'] %>
+  database: snackr_frontend_production
+  username: snackr_frontend
+  password: <%= ENV['SNACKR_FRONTEND_DATABASE_PASSWORD'] %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "snackr_backend_production"
+  # config.active_job.queue_name_prefix = "snackr_frontend_production"
 
   config.action_mailer.perform_caching = false
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "snackr-backend",
+  "name": "snackr-frontend",
   "private": true,
   "dependencies": {
     "@rails/actioncable": "^6.0.0",


### PR DESCRIPTION
This was bc of the initial repo name. Our DB for the frontend project was still snackr_backend_development etc, so everyone working on FE needs to run rails db:{drop, create} or you will have conflicts with the backend DB later most likely.